### PR TITLE
[v2] buildAll.sh: Add the installation

### DIFF
--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,8 +1,33 @@
 #!/bin/bash
 
 targets='PerfUtils CoreArbiter Arachne ArachnePerfTests arachne-sosp2017-benchmarks'
+targets_no_install='ArachnePerfTests'
+
+need_install()
+{
+    for dir in $targets_no_install; do
+        if [ "$1" = "$dir" ]; then
+            echo 0
+            return
+        fi
+    done
+
+    echo 1
+}
+
 for dir in $targets; do
+    echo "Processing $dir ..."
+
     pushd $dir > /dev/null
+
     make
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+
+    if [ `need_install $dir` -eq 1 ]; then
+        make install
+    fi
+
     popd > /dev/null
 done

--- a/cleanAll.sh
+++ b/cleanAll.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+targets='PerfUtils CoreArbiter Arachne ArachnePerfTests arachne-sosp2017-benchmarks'
+for dir in $targets; do
+    echo "Processing $dir ..."
+    pushd $dir > /dev/null
+    make clean
+    popd > /dev/null
+done


### PR DESCRIPTION
Otherwise, the include dirs and header files cannot be found by
dependent components.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>